### PR TITLE
活動記録の追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>TEAra-teamc</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -58,7 +58,7 @@ export default function Navbar() {
             {/* 活動ドロップダウン */}
             <button
               onClick={toggleActivityMenu}
-              className="text-blue-600 font-medium text-sm hover:text-blue-500 focus:outline-none bg-transparent border-none p-0">
+              className="font-medium text-[#646cff] hover:text-[#535bf2] focus:outline-none bg-transparent border-none p-0">
               活動
             </button>
             {isActivityOpen && (

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,8 +1,30 @@
 import { Link } from "react-router-dom";
+import { useState, useRef, useEffect } from "react";
 
 export default function Navbar() {
+  const [isActivityOpen, setIsActivityOpen] = useState(false);
+  const activityRef = useRef(null);
+
+  const toggleActivityMenu = () => {
+    setIsActivityOpen((prev) => !prev);
+  };
+
+  // 外側クリックで閉じる
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (activityRef.current && !activityRef.current.contains(event.target)) {
+        setIsActivityOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
   return (
-    <header className="relative w-full h-screen overflow-hidden">
+    <header className="relative w-full h-full">
       {/* 背景画像（画面全体）
       <div className="absolute inset-0 w-full h-full -z-10">
         <img
@@ -26,15 +48,37 @@ export default function Navbar() {
           お茶大生むけコミュニティ
         </p>
       </div>
-
-      {/* ナビバー */}
-      <nav className="absolute bottom-0 left-0 right-0 bg-gradient-to-r from-teal-400 to-green-400 shadow-md z-10">
-        <ul className="w-full flex justify-center gap-6 px-4 py-2 text-white font-medium text-sm">
+   {/* ナビバー */}
+   <nav className="absolute bottom-0 left-0 right-0 bg-gradient-to-r from-teal-400 to-green-400 shadow-md z-10">
+        <ul className="w-full flex justify-center gap-6 px-4 py-2 text-black font-medium text-sm">
           <li>
             <Link to="/">Home</Link>
           </li>
-          <li>
-            <Link to="/schedule">スケジュール</Link>
+      <li className="relative" ref={activityRef}>
+            {/* 活動ドロップダウン */}
+            <button
+              onClick={toggleActivityMenu}
+              className="text-blue-600 font-medium text-sm hover:text-blue-500 focus:outline-none bg-transparent border-none p-0">
+              活動
+            </button>
+            {isActivityOpen && (
+              <div className="absolute top-full left-0 mt-1 bg-white rounded shadow-lg py-2 w-36 z-50 border border-gray-200">
+                <Link
+                  to="/schedule"
+                  className="block px-4 py-2 text-gray-800 hover:bg-gray-100 hover:text-teal-600"
+                  onClick={() => setIsActivityOpen(false)}
+                >
+                  スケジュール
+                </Link>
+                <Link
+                  to="/record"
+                  className="block px-4 py-2 text-gray-800 hover:bg-gray-100 hover:text-teal-600"
+                  onClick={() => setIsActivityOpen(false)}
+                >
+                  活動記録
+                </Link>
+              </div>
+            )}
           </li>
           <li>
             <Link to="/members">members</Link>

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -1,0 +1,187 @@
+import { useState, useRef } from 'react';
+
+export default function Record() {
+  // 年度ごとの開閉状態
+  const [openYears, setOpenYears] = useState({
+    '2024': true,
+    '2023': true,
+    '2022': true,
+    '2021': true
+  });
+  
+  // 各年度のリファレンスを保持
+  const yearRefs = {
+    '2024': useRef(null),
+    '2023': useRef(null),
+    '2022': useRef(null),
+    '2021': useRef(null)
+  };
+
+  // 年度の開閉を切り替える関数
+  const toggleYear = (year) => {
+    setOpenYears(prev => ({
+      ...prev,
+      [year]: !prev[year]
+    }));
+    
+  };
+
+  // 2024年度のイベントデータ
+  const events2024 = {
+    company: [
+      { month: '8月', title: 'マイクロソフト オフィス訪問' },
+      { month: '9月', title: 'メルカリ オフィス訪問'},
+      { month: '11月', title: '日経新聞社 オフィス訪問'},
+      { month: '12月', title: 'マイクロソフト座談会' }
+    ],
+    workshop: [
+      { month: '4月', title: 'gitゆるゆる勉強会'},
+      { month: '5月', title: 'フロントエンド入門'},
+      { month: '6月', title: 'バックエンド入門'},
+      { month: '7月', title: 'アルゴリズム勉強会'},
+      { month: '9月', title: 'バックエンドWorkshop'},
+      { month: '10月', title: 'フロントエンドWorkshop'},
+      { month: '11月', title: '徽音祭 LT会、展示参加' }
+    ]
+  };
+
+
+  // 過去の年度のイベントデータ
+  const pastEvents = {
+    '2023': [
+      { title: '・定期的にもくもく会開催' },
+      { title: '・Tech Circle Expo参加' },
+      { title: '・Tech Circle Expo LT大会参加' }
+    ],
+    '2022': [
+      { title: '・WiCySに加入' },
+      { title: '・Android入門' },
+      { title: '・セキュリティ勉強会' }
+    ],
+    '2021': [
+      { title: '・TEAra創立' },
+      { title: '・オリエンテーション' },
+      { title: '・Firebase で Web ページをホスティングするWorkshop' },
+      { title: '・バックエンドWorkshop' },
+      { title: '・git講座' },
+      { title: '・部内LT大会' },
+      { title: '・新人研修資料勉強会' }
+    ]
+  };
+
+  // 歴史のタイムライン
+  const historyTimeline = [
+    { year: '2021', event: '@Tori先輩と@hunachi先輩によって創立' },
+    { year: '2021', event: '色々なイベントを実施' },
+    { year: '2022', event: 'WiCySに加入、外部とのイベントを実施' },
+    { year: '2024', event: 'TheTechExpoに参加' }
+  ];
+
+  return (
+    <div className="bg-gradient-to-b from-green-50 to-white min-h-screen py-8 px-4 pb-40">
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold text-center mb-10 text-gray-800">
+        活動記録
+      </h1>
+  
+      {/* 歴史のタイムライン */}
+      <section className="mb-20 max-w-3xl mx-auto">
+        <h2 className="text-2xl font-semibold mb-6 border-b-2 pb-2 text-gray-800">
+          TEAraの歴史
+        </h2>
+        <div className="relative pl-8 border-l-2 border-teal-300">
+          {historyTimeline.map((item, index) => (
+            <div key={index} className="mb-6 relative">
+              <div className="absolute -left-10 w-5 h-5 rounded-full bg-teal-500"></div>
+              <div className="bg-white p-4 rounded-lg shadow-sm">
+                <span className="text-teal-600 font-semibold">{item.year}</span>
+                <p className="text-gray-700">{item.event}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+  
+      {/* 2024年度 */}
+      <section className="mb-4 max-w-3xl mx-auto" ref={yearRefs['2024']}>
+        <div
+          className="flex justify-between items-center bg-gray-100 p-3 rounded cursor-pointer hover:bg-gray-200"
+          onClick={() => toggleYear('2024')}
+        >
+          <h2 className="text-xl font-semibold text-gray-800">2024年度</h2>
+          <span className="text-teal-600 text-2xl">
+            {openYears['2024'] ? '−' : '+'}
+          </span>
+        </div>
+  
+        {openYears['2024'] && (
+          <div className="bg-white p-5 rounded-b-xl shadow-sm border border-t-0 border-gray-200">
+            <div className="mb-6">
+              <h3 className="text-lg font-semibold text-teal-700 mb-3 border-b pb-2">
+                企業関連
+              </h3>
+              <ul className="space-y-3">
+                {events2024.company.map((event, index) => (
+                  <li key={index} className="flex items-start">
+                    <span className="text-teal-600 font-medium min-w-12">{event.month}</span>
+                    <div className="ml-2">
+                      <div className="text-gray-800">{event.title}</div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+  
+            <div>
+              <h3 className="text-lg font-semibold text-teal-700 mb-3 border-b pb-2">
+                Workshop・勉強会
+              </h3>
+              <ul className="space-y-3">
+                {events2024.workshop.map((event, index) => (
+                  <li key={index} className="flex items-start">
+                    <span className="text-teal-600 font-medium min-w-12">{event.month}</span>
+                    <div className="ml-2">
+                      <div className="text-gray-800">{event.title}</div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+      </section>
+  
+      {/* 過去の年度（折りたたみ式） */}
+      {Object.keys(pastEvents)
+        .sort((a, b) => parseInt(b) - parseInt(a))
+        .map((year) => (
+          <section key={year} className="mb-4 max-w-3xl mx-auto" ref={yearRefs[year]}>
+            <div
+              className="flex justify-between items-center bg-gray-100 p-3 rounded shadow-sm border border-gray-200 cursor-pointer hover:bg-gray-200"
+              onClick={() => toggleYear(year)}
+            >
+              <h2 className="text-xl font-semibold text-gray-800">{year}年度</h2>
+              <span className="text-teal-600 text-2xl">{openYears[year] ? '−' : '+'}</span>
+            </div>
+  
+            <div
+              className={`overflow-hidden transition-all duration-300 ${
+                openYears[year] ? 'max-h-[1000px]' : 'max-h-0'
+              }`}
+            >
+              <div className="bg-white p-5 rounded-b-xl shadow-sm border border-t-0 border-gray-200">
+                <ul className="space-y-3">
+                  {pastEvents[year].map((event, index) => (
+                    <li key={index} className="flex items-start">
+                      <div className="ml-2 text-gray-800">{event.title}</div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </section>
+        ))}
+    </div>
+  </div>
+  );
+}

--- a/src/pages/Schedule.jsx
+++ b/src/pages/Schedule.jsx
@@ -172,7 +172,7 @@ export default function Schedule() {
   ];
 
   return (
-    <div className="bg-gradient-to-b from-green-50 to-white min-h-screen py-8 px-4 overflow-hidden">
+    <div className="bg-gradient-to-b from-green-50 to-white min-h-screen py-8 px-4 pb-20 overflow-hidden">
       <div className="max-w-6xl mx-auto">
         {/* スケジュールの見出し */}
         <h1 className="text-3xl font-bold text-center mb-8">


### PR DESCRIPTION
### 活動記録ページの追加
・Discordに写真を送ったものから変更していません

### Navbarの変更
・活動ボタンを作成→ドロップダウンが出てきて、スケジュールか活動記録か選択する。
もう一度「活動」を押すか、それ以外の場所をタップすると閉じる。


<img width="570" alt="スクリーンショット 0007-05-10 0 51 51" src="https://github.com/user-attachments/assets/294296c5-d377-4b1a-945f-48c1715a3e6a" />

### その他
・スケジュールのページの下部に余白を入れるようにしました。

**・ Webサイトのタイトルを、TEAra-teamcに変更しました。**

<img width="187" alt="スクリーンショット 0007-05-10 0 53 42" src="https://github.com/user-attachments/assets/33a361cc-aee5-4c47-9aca-9c53c80fede3" />
