### PR TITLE
Homeにニュース追加、活動ページの色味変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TEAra-teamc</title>
+    <style>
+      html {
+        scroll-behavior: smooth;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Schedule from "./pages/Schedule";
 import Members from "./pages/Members";
 import News from "./pages/News";
 import Links from "./pages/Links";
+import Record from "./pages/Record";
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/schedule" element={<Schedule />} />
+        <Route path="/record" element={<Record />} />
         <Route path="/members" element={<Members />} />
         <Route path="/news" element={<News />} />
         <Route path="/links" element={<Links />} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -24,7 +24,7 @@ export default function Navbar() {
   }, []);
 
   return (
-    <header className="relative w-full h-full">
+    <header className="relative w-full h-[66%]">
       {/* 背景画像（画面全体）
       <div className="absolute inset-0 w-full h-full -z-10">
         <img

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,47 @@
 export default function Home() {
+
+    // ニュースデータ（将来的にAPIやDBから取得するように変更できます）
+    const newsItems = [
+      {
+        id: 1,
+        date: "2025.5.3",
+        title: "TEAra Hack 2025 開催！！",
+        link: "#hackSection"
+      },
+      // 将来的に追加するニュースはここに追加できます
+      // {
+      //   id: 2,
+      //   date: "2025.4.20",
+      //   title: "サンプルニュース2",
+      //   link: "#hackSection"
+      // },
+    ];
+
+   // スムーズスクロール用の関数
+  const smoothScroll = (e) => {
+    e.preventDefault();
+    const href = e.currentTarget.getAttribute("href");
+    if (href.startsWith("#")) {
+      const targetId = href.substring(1);
+      const targetElement = document.getElementById(targetId);
+      if (targetElement) {
+        targetElement.scrollIntoView({
+          behavior: "smooth",
+          block: "start"
+        });
+      }
+    }
+  };
+
   return (
     <main className="w-full min-h-screen bg-white">
+      {/* グローバルスタイル - スムーズスクロール用 */}
+      <style jsx global>{`
+        html {
+          scroll-behavior: smooth;
+        }
+      `}</style>
+
 
       {/* セクション1：キャッチコピー */}
       <section className="relative flex flex-col items-center justify-center text-center py-20 px-6 bg-gradient-to-b from-green-100 to-white overflow-hidden">
@@ -20,22 +61,50 @@ export default function Home() {
           初めてでも大歓迎！まずはこのハッカソンから一緒にやってみませんか？
         </p>
       </section>
-      {/* セクション2：画像 */}
-<section className="flex justify-center py-16 px-4 bg-white">
-  <div className="relative w-full max-w-3xl">
-    {/* 背景のふわっと丸い色 */}
-    <div className="absolute -top-6 -left-6 w-full h-full bg-teal-100 rounded-3xl blur-xl opacity-40 z-0" />
-    
-    {/* 画像本体 */}
-    <img
-      src="/Hack.png"
-      alt="TEAra Hackathon Banner"
-      className="relative z-10 w-full rounded-2xl shadow-xl transform transition duration-300 hover:scale-105"
-    />
-  </div>
-</section>
 
-      {/* セクション3：CTA */}
+        {/* セクション2：最新ニュース */}
+        <section className="py-4 px-6 bg-white mb-8">
+          <div className="max-w-2xl mx-auto">
+            <h3 className="text-2xl md:text-3xl font-bold text-center mb-8 text-teal-700">最新ニュース</h3>
+            <div className="relative bg-white shadow-md rounded-lg p-3">
+            <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-lime-300 via-emerald-300 to-lime-300 rounded-b-lg" />
+              <ul className="divide-y divide-gray-200">
+                {newsItems.map((news) => (
+                  <li key={news.id} className="py-4">
+                    <a 
+                      href={news.link} 
+                      className="block hover:bg-gray-50 transition p-2 rounded"
+                      onClick={smoothScroll}
+                    >
+                      <div className="flex items-baseline">
+                        <span className="text-teal-500 font-medium mr-3">{news.date}</span>
+                        <span className="text-teal-700">{news.title}</span>
+                      </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+              <div className="absolute bottom-0 left-0 w-full h-1 bg-gradient-to-r from-lime-300 via-emerald-300 to-lime-300 rounded-b-lg" />
+            </div>
+          </div>
+        </section>
+
+    {/*セクション3:画像*/}
+    <section id="hackSection"  className="flex justify-center py-16 px-4 bg-white">
+      <div className="relative w-full max-w-3xl">
+        {/* 背景のふわっと丸い色 */}
+        <div className="absolute -top-6 -left-6 w-full h-full bg-teal-100 rounded-3xl blur-xl opacity-40 z-0" />
+        
+        {/* 画像本体 */}
+        <img
+          src="/Hack.png"
+          alt="TEAra Hackathon Banner"
+          className="relative z-10 w-full rounded-2xl shadow-xl transform transition duration-300 hover:scale-105"
+        />
+      </div>
+    </section>
+
+      {/* セクション4：CTA */}
       <section className="text-center py-20 px-6 bg-gradient-to-r from-teal-100 via-green-100 to-teal-100">
         <h3 className="text-2xl md:text-3xl font-semibold text-emerald-800 mb-4">
           2025年春のハッカソン、開催中！

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -78,110 +78,116 @@ export default function Record() {
   ];
 
   return (
-    <div className="bg-gradient-to-b from-green-50 to-white min-h-screen py-8 px-4 pb-40">
-    <div className="max-w-4xl mx-auto">
-      <h1 className="text-3xl font-bold text-center mb-10 text-gray-800">
-        活動記録
-      </h1>
-  
-      {/* 歴史のタイムライン */}
-      <section className="mb-20 max-w-3xl mx-auto">
-        <h2 className="text-2xl font-semibold mb-6 border-b-2 pb-2 text-gray-800">
-          TEAraの歴史
-        </h2>
-        <div className="relative pl-8 border-l-2 border-teal-300">
-          {historyTimeline.map((item, index) => (
-            <div key={index} className="mb-6 relative">
-              <div className="absolute -left-10 w-5 h-5 rounded-full bg-teal-500"></div>
-              <div className="bg-white p-4 rounded-lg shadow-sm">
-                <span className="text-teal-600 font-semibold">{item.year}</span>
-                <p className="text-gray-700">{item.event}</p>
+    <section className="bg-lime-50 min-h-screen py-20 px-6 pb-40">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-center text-3xl md:text-4xl font-bold mb-4 text-emerald-700">
+          活動記録
+        </h1>
+        <div className="w-24 h-1.5 rounded-full bg-teal-400 mb-16 mx-auto" />
+        
+        {/* 歴史のタイムライン */}
+        <section className="relative bg-white rounded-lg py-12 px-6 mb-20 max-w-3xl mx-auto shadow-lg">
+          {/* グラデーションの上部 */}
+          <div className="absolute top-0 left-0 w-full h-2 bg-gradient-to-r from-lime-300 via-emerald-300 to-lime-300 rounded-t-lg" />
+
+          <h2 className="text-2xl font-semibold mb-6 border-b-2 pb-2 text-emerald-700">
+            TEAraの歴史
+          </h2>
+          <div className="relative pl-8 border-l-4 border-teal-400">
+            {historyTimeline.map((item, index) => (
+              <div key={index} className="mb-6 relative">
+                <div className="absolute -left-10 w-5 h-5 rounded-full bg-teal-500"></div>
+                <div className="bg-white p-4 rounded-lg border border-gray-200">
+                  <span className="text-teal-600 font-semibold">{item.year}</span>
+                  <p className="text-gray-700">{item.event}</p>
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      </section>
-  
-      {/* 2024年度 */}
-      <section className="mb-4 max-w-3xl mx-auto" ref={yearRefs['2024']}>
-        <div
-          className="flex justify-between items-center bg-gray-100 p-3 rounded cursor-pointer hover:bg-gray-200"
-          onClick={() => toggleYear('2024')}
-        >
-          <h2 className="text-xl font-semibold text-gray-800">2024年度</h2>
-          <span className="text-teal-600 text-2xl">
-            {openYears['2024'] ? '−' : '+'}
-          </span>
-        </div>
-  
-        {openYears['2024'] && (
-          <div className="bg-white p-5 rounded-b-xl shadow-sm border border-t-0 border-gray-200">
-            <div className="mb-6">
-              <h3 className="text-lg font-semibold text-teal-700 mb-3 border-b pb-2">
-                企業関連
-              </h3>
-              <ul className="space-y-3">
-                {events2024.company.map((event, index) => (
-                  <li key={index} className="flex items-start">
-                    <span className="text-teal-600 font-medium min-w-12">{event.month}</span>
-                    <div className="ml-2">
-                      <div className="text-gray-800">{event.title}</div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-  
-            <div>
-              <h3 className="text-lg font-semibold text-teal-700 mb-3 border-b pb-2">
-                Workshop・勉強会
-              </h3>
-              <ul className="space-y-3">
-                {events2024.workshop.map((event, index) => (
-                  <li key={index} className="flex items-start">
-                    <span className="text-teal-600 font-medium min-w-12">{event.month}</span>
-                    <div className="ml-2">
-                      <div className="text-gray-800">{event.title}</div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
+            ))}
           </div>
-        )}
-      </section>
-  
-      {/* 過去の年度（折りたたみ式） */}
-      {Object.keys(pastEvents)
-        .sort((a, b) => parseInt(b) - parseInt(a))
-        .map((year) => (
-          <section key={year} className="mb-4 max-w-3xl mx-auto" ref={yearRefs[year]}>
-            <div
-              className="flex justify-between items-center bg-gray-100 p-3 rounded shadow-sm border border-gray-200 cursor-pointer hover:bg-gray-200"
-              onClick={() => toggleYear(year)}
-            >
-              <h2 className="text-xl font-semibold text-gray-800">{year}年度</h2>
-              <span className="text-teal-600 text-2xl">{openYears[year] ? '−' : '+'}</span>
-            </div>
-  
-            <div
-              className={`overflow-hidden transition-all duration-300 ${
-                openYears[year] ? 'max-h-[1000px]' : 'max-h-0'
-              }`}
-            >
-              <div className="bg-white p-5 rounded-b-xl shadow-sm border border-t-0 border-gray-200">
+
+          {/* グラデーションの下部 */}
+          <div className="absolute bottom-0 left-0 w-full h-2 bg-gradient-to-r from-lime-300 via-emerald-300 to-lime-300 rounded-b-lg" />
+        </section>
+
+        <section className="mb-4 max-w-3xl mx-auto" ref={yearRefs['2024']}>
+          <div
+            className="flex justify-between items-center bg-gray-100 p-3 rounded shadow-md cursor-pointer hover:bg-gray-200"
+            onClick={() => toggleYear('2024')}
+          >
+            <h2 className="text-xl font-semibold text-gray-800">2024年度</h2>
+            <span className="text-teal-600 text-2xl">
+              {openYears['2024'] ? '−' : '+'}
+            </span>
+          </div>
+
+          {openYears['2024'] && (
+            <div className="bg-white p-5 rounded-b-xl shadow-md border border-t-0 border-gray-200">
+              <div className="mb-6">
+                <h3 className="text-lg font-semibold text-teal-700 mb-3 border-b pb-2">
+                  企業関連
+                </h3>
                 <ul className="space-y-3">
-                  {pastEvents[year].map((event, index) => (
+                  {events2024.company.map((event, index) => (
                     <li key={index} className="flex items-start">
-                      <div className="ml-2 text-gray-800">{event.title}</div>
+                      <span className="text-teal-600 font-medium min-w-12">{event.month}</span>
+                      <div className="ml-2">
+                        <div className="text-gray-800">{event.title}</div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold text-teal-700 mb-3 border-b pb-2">
+                  Workshop・勉強会
+                </h3>
+                <ul className="space-y-3">
+                  {events2024.workshop.map((event, index) => (
+                    <li key={index} className="flex items-start">
+                      <span className="text-teal-600 font-medium min-w-12">{event.month}</span>
+                      <div className="ml-2">
+                        <div className="text-gray-800">{event.title}</div>
+                      </div>
                     </li>
                   ))}
                 </ul>
               </div>
             </div>
-          </section>
-        ))}
-    </div>
-  </div>
+          )}
+        </section>
+
+        {/* 過去の年度（折りたたみ式） */}
+        {Object.keys(pastEvents)
+          .sort((a, b) => parseInt(b) - parseInt(a))
+          .map((year) => (
+            <section key={year} className="mb-4 max-w-3xl mx-auto" ref={yearRefs[year]}>
+              <div
+                className="flex justify-between items-center bg-gray-100 p-3 rounded shadow-md cursor-pointer hover:bg-gray-200"
+                onClick={() => toggleYear(year)}
+              >
+                <h2 className="text-xl font-semibold text-gray-800">{year}年度</h2>
+                <span className="text-teal-600 text-2xl">{openYears[year] ? '−' : '+'}</span>
+              </div>
+
+              <div
+                className={`overflow-hidden transition-all duration-300 ${
+                  openYears[year] ? 'max-h-[1000px]' : 'max-h-0'
+                }`}
+              >
+                <div className="bg-white p-5 rounded-b-xl shadow-md border border-t-0 border-gray-200">
+                  <ul className="space-y-3">
+                    {pastEvents[year].map((event, index) => (
+                      <li key={index} className="flex items-start">
+                        <div className="ml-2 text-gray-800">{event.title}</div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </section>
+          ))}
+      </div>
+    </section>
   );
 }

--- a/src/pages/Schedule.jsx
+++ b/src/pages/Schedule.jsx
@@ -172,12 +172,13 @@ export default function Schedule() {
   ];
 
   return (
-    <div className="bg-gradient-to-b from-green-50 to-white min-h-screen py-8 px-4 pb-20 overflow-hidden">
+    <div className="bg-lime-50 min-h-screen py-20 px-4 pb-20 overflow-hidden">
       <div className="max-w-6xl mx-auto">
         {/* スケジュールの見出し */}
-        <h1 className="text-3xl font-bold text-center mb-8">
-          TEAra 年間スケジュール
+        <h1 className="text-center text-3xl md:text-4xl font-bold  mb-4 text-emerald-700">
+        TEAra 年間スケジュール
         </h1>
+        <div className="w-24 h-1.5 rounded-full bg-teal-400 mb-16 mx-auto" />
 
         {/* カテゴリ別のフィルター */}
         <div className="mb-8 flex flex-wrap justify-center gap-2">


### PR DESCRIPTION
### Homeに最新ニュースを追加しました
ニュースは5個まで表示されるようになっています。
今回のハッカソン開催のニュースを押すと、下のパンフレットにスクロールするようになっています。

<img width="1467" alt="スクリーンショット 0007-05-16 17 59 35" src="https://github.com/user-attachments/assets/2c37a5ee-6e9f-4c07-824e-ddf1cd201984" />
-



### 活動記録とスケジュールページの背景色を変更しました
<img width="1468" alt="スクリーンショット 0007-05-16 17 59 01" src="https://github.com/user-attachments/assets/3bb517e7-90b2-4704-9708-56ec9ae5e8ca" />

-


<img width="1470" alt="スクリーンショット 0007-05-16 17 58 47" src="https://github.com/user-attachments/assets/9d24e6cf-b82f-4a37-9ced-9f7d3b97b4dd" />
-


### ヘッダーを画面全体の66%の大きさにしました。
<img width="1470" alt="スクリーンショット 0007-05-16 18 32 28" src="https://github.com/user-attachments/assets/6f07bae9-df28-42dd-b540-e2a705b75f02" />


